### PR TITLE
Update `dump_to_hex` format code

### DIFF
--- a/one_frontrun.py
+++ b/one_frontrun.py
@@ -22,7 +22,7 @@ def log(*args):
 
 
 def dump_to_hex(integer):
-  return '0x' + format(integer, 'x')
+  return '{:#x}'.format(integer)
 
 
 def send_request(request):


### PR DESCRIPTION
@bogatyy ,

I enjoyed the article and while reading through the code I noticed that `dump_to_hex` could be slightly simplified.

https://github.com/bogatyy/bancor/blob/69a63711b24587b04814e755e89d716c21c8fbe4/one_frontrun.py#L25

```python
>>> def dump_to_hex(integer):
...   return '0x' + format(integer, 'x')
... 
>>> def dump_to_hex2(integer):
...   return '{:#x}'.format(integer)
... 
>>> import random
>>> import sys
>>> rand_ints = (random.randint(0, sys.maxint) for _ in range(10000))
>>> all(dump_to_hex(i) == dump_to_hex2(i) for i in rand_ints)
True
```

[Replacing %x and %o and converting the value to different bases:](https://docs.python.org/2/library/string.html#format-examples)
```python
>>> # format also supports binary numbers
>>> "int: {0:d};  hex: {0:x};  oct: {0:o};  bin: {0:b}".format(42)
'int: 42;  hex: 2a;  oct: 52;  bin: 101010'
>>> # with 0x, 0o, or 0b as prefix:
>>> "int: {0:d};  hex: {0:#x};  oct: {0:#o};  bin: {0:#b}".format(42)
'int: 42;  hex: 0x2a;  oct: 0o52;  bin: 0b101010'
```
---
On a side not, it also handles negative numbers (although I'm guessing that `perform_simple_buy` wouldn't work with negative numbers anyways).

```python
>>> dump_to_hex(-1119)
'0x-45f'
>>> 0x-45f
  File "<input>", line 1
    0x-45f
     ^
SyntaxError: invalid token
>>> dump_to_hex2(-1119)
'-0x45f'
>>> -0x45f
-1119
```

Thanks again for the article and code!
